### PR TITLE
automate github releases upload based on tags

### DIFF
--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
     tags:
-      - *
+      - '*'
   pull_request:
     branches: [ master ]
 jobs:

--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -33,15 +33,10 @@ jobs:
       with:
         name: OpenArena-macOS-x86_64
         path: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
-  
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Release
-        uses: fnkr/github-action-ghr@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GHR_COMPRESS: zip
-          GHR_PATH: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Release
+      uses: fnkr/github-action-ghr@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      env:
+        GHR_COMPRESS: zip
+        GHR_PATH: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -33,3 +33,15 @@ jobs:
       with:
         name: OpenArena-macOS-x86_64
         path: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
+  
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release
+        uses: fnkr/github-action-ghr@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GHR_COMPRESS: zip
+          GHR_PATH: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -3,8 +3,6 @@ name: CI Builds
 on:
   push:
     branches: [ master ]
-    tags:
-      - '*'
   pull_request:
     branches: [ master ]
 jobs:
@@ -33,10 +31,3 @@ jobs:
       with:
         name: OpenArena-macOS-x86_64
         path: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
-    - name: Release
-      uses: fnkr/github-action-ghr@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      env:
-        GHR_COMPRESS: zip
-        GHR_PATH: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -5,7 +5,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
+  create:
+    tags:
+      - *
 jobs:
   build:
 
@@ -32,15 +34,3 @@ jobs:
       with:
         name: OpenArena-macOS-x86_64
         path: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Release
-        uses: fnkr/github-action-ghr@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GHR_COMPRESS: zip
-          GHR_PATH: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -32,3 +32,15 @@ jobs:
       with:
         name: OpenArena-macOS-x86_64
         path: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release
+        uses: fnkr/github-action-ghr@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GHR_COMPRESS: zip
+          GHR_PATH: engine/openarena-engine-source-*/build/release-darwin-x86_64/*.x86_64
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_builds.yml
+++ b/.github/workflows/ci_builds.yml
@@ -3,11 +3,10 @@ name: CI Builds
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
-  create:
     tags:
       - *
+  pull_request:
+    branches: [ master ]
 jobs:
   build:
 

--- a/.github/workflows/ci_releases.yml
+++ b/.github/workflows/ci_releases.yml
@@ -1,0 +1,26 @@
+name: CI Releases
+
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download artifact
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ci_builds.yml
+        workflow_conclusion: success
+        commit: ${{github.event.pull_request.head.sha}}
+        path: ./artifacts/
+        event: push
+    - name: Release
+      uses: fnkr/github-action-ghr@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      env:
+        GHR_COMPRESS: zip
+        GHR_PATH: ./artifacts/
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_releases.yml
+++ b/.github/workflows/ci_releases.yml
@@ -14,7 +14,6 @@ jobs:
       with:
         workflow: ci_builds.yml
         workflow_conclusion: success
-        commit: ${{github.event.pull_request.head.sha}}
         path: ./artifacts/
         event: push
     - name: Release


### PR DESCRIPTION
Hey there, related to https://github.com/OpenArena/legacy/issues/1 I managed to get releases creation with some actions by first downloading the artifacts from the macos workflow and then uploading it when a tag is pushed.

I'm not sure if there's still something to do, I wasn't too much attentive but felt that the release workflow succeeded before the actual build so it might have used a previous succeeding build, we should confirm this before merging, hence I'm creating this pr as a draft.
Edit: I think I solved it by removing some params and sticking to default. 👍 


I tried it as I have a similar issue here:  
https://github.com/GabLeRoux/macos-crossover-wine-cloud-builder/issues/25

Also, commits should be squashed, I just tried a few things before it gets to work.

Releases confirmed working here:  
https://github.com/GabLeRoux/OpenArena-legacy/releases